### PR TITLE
Order and Limit queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.rspec
+.ruby-version
+.ruby-gemset
 *.gem
 *.rbc
 .bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ rvm:
 
 services:
   - cassandra
+
+before_install:
+  - sudo sh -c "echo 'JVM_OPTS=\"$JVM_OPTS -Djava.net.preferIPv4Stack=false\"' >> /usr/local/cassandra/conf/cassandra-env.sh"
+  - sudo service cassandra start

--- a/README.md
+++ b/README.md
@@ -77,13 +77,12 @@ company_names = Companies.all.map(&:name)
 ````
 
 ## TODO / Missing
-1. order and limit queries
-2. Support ALLOW FILTERING
-3. Create / filter with index
-4. Model attributes that are not Cassandra columns
-5. Delete models
-6. Counters
-7. Schema creation / migration
+1. Support ALLOW FILTERING
+2. Create / filter with index
+3. Model attributes that are not Cassandra columns
+4. Delete models
+5. Counters
+6. Schema creation / migration
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Virsandra is meant to make it easy to use cassandra for persistence
 for models build with virtus.
 
 The feature set will likely remain simple, the idea is to not block
-development of other projects while the implentation of CQL changes
+development of other projects while the implantation of CQL changes
 quickly.
 
 ## Schema yourself
 
 At this stage, you're on your own in terms for schema management. The
 gem expects you have maintain table <=> model attribute mappings
-youself.
+yourself.
 
 ## Example usage
 
@@ -67,7 +67,7 @@ company.attributes
 #=> {name: "Gooble", founder: "Larry Brin", turnover: 2000000, founded: 2012}
 ````
 
-Seach for companies:
+Search for companies:
 ````ruby
 companies = Companies.all
 

--- a/lib/virsandra/queries/add_query.rb
+++ b/lib/virsandra/queries/add_query.rb
@@ -1,0 +1,25 @@
+module Virsandra
+  class AddQuery < Query
+    def initialize(column_name, column_type = nil)
+      @column_name = column_name
+      @column_type = column_type.to_s.empty? ? "varchar" : column_type
+    end
+
+    def to_s
+      validate
+      super
+    end
+
+    private
+
+    def raw_query
+      ["ADD", @column_name, @column_type]
+    end
+
+    def validate
+      if @column_name.to_s.empty?
+        raise InvalidQuery.new("You must specify column name")
+      end
+    end
+  end
+end

--- a/lib/virsandra/queries/alter_query.rb
+++ b/lib/virsandra/queries/alter_query.rb
@@ -1,0 +1,34 @@
+module Virsandra
+  class AlterQuery < Query
+    def initialize(skip_validation = false)
+      @skip_validation = skip_validation
+    end
+
+    def table(table_name)
+      @table = TableQuery.new("TABLE", table_name)
+      self
+    end
+
+    def add(column_name, column_type = nil)
+      @add = AddQuery.new(column_name, column_type)
+      self
+    end
+
+    def to_s
+      validate
+      super
+    end
+
+    private
+
+    def raw_query
+      ["ALTER", @table, @add]
+    end
+
+    def validate
+      if !@skip_validation && @table.to_s.empty?
+        raise InvalidQuery.new("You must set the table")
+      end
+    end
+  end
+end

--- a/lib/virsandra/queries/delete_query.rb
+++ b/lib/virsandra/queries/delete_query.rb
@@ -1,0 +1,25 @@
+module Virsandra
+  class DeleteQuery < Query
+
+    def from(table)
+      @from = TableQuery.new("FROM" ,table)
+      self
+    end
+    alias_method :table, :from
+
+    def where(clause)
+      unless @where
+        @where = WhereQuery.new(clause)
+      else
+        @where += WhereQuery.new(clause)
+      end
+      self
+    end
+
+    private
+
+    def raw_query
+      ["DELETE", @from.to_s, @where.to_s]
+    end
+  end
+end

--- a/lib/virsandra/queries/insert_query.rb
+++ b/lib/virsandra/queries/insert_query.rb
@@ -1,0 +1,34 @@
+module Virsandra
+  class InsertQuery < Query
+
+    def into(table_name)
+      @into = TableQuery.new("INTO", table_name)
+      self
+    end
+
+    def values(values)
+      @values = ValuesQuery.new(values)
+      self
+    end
+
+    def to_s
+      validate
+      super
+    end
+
+    private
+
+    def raw_query
+      ["INSERT", @into, @values]
+    end
+
+    def validate
+      if @into.to_s.empty?
+        raise InvalidQuery.new("You must set into")
+      end
+      if @values.to_s.empty?
+        raise InvalidQuery.new("You must set values")
+      end
+    end
+  end
+end

--- a/lib/virsandra/queries/limit_query.rb
+++ b/lib/virsandra/queries/limit_query.rb
@@ -1,0 +1,17 @@
+module Virsandra
+  class LimitQuery < Query
+    def initialize(number)
+      @number = number
+    end
+
+    private
+
+    def raw_query
+      if @number.to_i > 0
+        ["LIMIT", @number]
+      else
+        raise InvalidQuery.new("Limit must be positive number")
+      end
+    end
+  end
+end

--- a/lib/virsandra/queries/order_query.rb
+++ b/lib/virsandra/queries/order_query.rb
@@ -1,0 +1,36 @@
+module Virsandra
+  class OrderQuery < Query
+    VALID_ORDERS = ["ASC", "DESC"]
+
+    def initialize(columns)
+      @columns = columns
+    end
+
+    private
+
+    def raw_query
+      [@columns.nil? ? "" : "ORDER BY" ,columns_as_string]
+    end
+
+    def columns_as_string
+      if @columns.respond_to?(:each_pair)
+        result = []
+        @columns.each_pair do |column_name, order|
+          result << column_as_string(column_name, order)
+        end
+        result.join(", ")
+      else
+        @columns.to_s
+      end
+    end
+
+    def column_as_string(column_name, order)
+      normalized_order = order.to_s.upcase
+      if VALID_ORDERS.include?(normalized_order)
+        "#{column_name} #{normalized_order}"
+      else
+        raise InvalidQuery.new("Unknown order #{order}")
+      end
+    end
+  end
+end

--- a/lib/virsandra/queries/select_query.rb
+++ b/lib/virsandra/queries/select_query.rb
@@ -1,0 +1,62 @@
+module Virsandra
+  class SelectQuery < Query
+    def initialize(columns = nil, skip_validation = false)
+      @columns = columns
+      @skip_validation = skip_validation
+    end
+
+    def from(table)
+      @from = TableQuery.new("FROM", table)
+      self
+    end
+
+    def where(clause)
+      unless @where
+        @where = WhereQuery.new(clause)
+      else
+        @where += WhereQuery.new(clause)
+      end
+      self
+    end
+
+    def order(columns)
+      @order = OrderQuery.new(columns)
+      self
+    end
+
+    def limit(number)
+      @limit = LimitQuery.new(number)
+      self
+    end
+
+    def reset
+      @where, @order, @limit = nil
+    end
+
+    def to_s
+      validate
+      super
+    end
+
+    private
+
+    def raw_query
+      ["SELECT", columns_as_string, @from, @where, @order, @limit]
+    end
+
+    def columns_as_string
+      converted_columns = if @columns.respond_to?(:join)
+        @columns.join(", ")
+      else
+        @columns.to_s
+      end
+      converted_columns.empty? ? "*" : converted_columns
+    end
+
+    def validate
+      if !@skip_validation && @from.to_s.empty?
+        raise InvalidQuery.new("You must set from")
+      end
+    end
+  end
+end

--- a/lib/virsandra/queries/table_query.rb
+++ b/lib/virsandra/queries/table_query.rb
@@ -1,0 +1,13 @@
+module Virsandra
+  class TableQuery < Query
+    def initialize(keyword, table_name)
+      @table_name, @keyword = table_name, keyword
+    end
+
+    private
+
+    def raw_query
+      [@table_name.to_s.empty? ? "" : @keyword, @table_name]
+    end
+  end
+end

--- a/lib/virsandra/queries/values_query.rb
+++ b/lib/virsandra/queries/values_query.rb
@@ -1,0 +1,41 @@
+module Virsandra
+  class ValuesQuery < Query
+    def initialize(values)
+      @values = values
+    end
+
+    private
+
+    def raw_query
+      [values_to_string]
+    end
+
+    def values_to_string
+      if @values.respond_to?(:each_pair)
+        if values_str = values_as_string and !values_str.empty?
+          "(#{columns_as_string}) VALUES (#{values_str})"
+        else
+          ""
+        end
+      else
+        ""
+      end
+    end
+
+    def columns_as_string
+      columns = []
+      @values.each_pair do |key, value|
+        columns << key unless value.nil?
+      end
+      columns.join(", ")
+    end
+
+    def values_as_string
+      values = []
+      @values.each_pair do |key, value|
+        values << CQLValue.convert(value) unless value.nil?
+      end
+      values.join(", ")
+    end
+  end
+end

--- a/lib/virsandra/queries/where_query.rb
+++ b/lib/virsandra/queries/where_query.rb
@@ -17,7 +17,7 @@ module Virsandra
       if where_query.is_a?(self.class)
         @clause = [to_s, where_query.to_s.gsub(/^WHERE\s+/, "")].join(" AND ")
       else
-        raise InvalidQuery("WhereQuery can be mereged only with other WhereQuery")
+        raise InvalidQuery.new("WhereQuery can be mereged only with other WhereQuery")
       end
     end
     alias_method :merge, :+

--- a/lib/virsandra/queries/where_query.rb
+++ b/lib/virsandra/queries/where_query.rb
@@ -1,0 +1,69 @@
+module Virsandra
+  class WhereQuery < Query
+    OPERATOR_MAPPING = {
+      :lt => "<",
+      :gt => ">",
+      :eq => "=",
+      :lt_or_eq => "<=",
+      :gt_or_eq => ">=",
+      :in => "IN"
+    }
+
+    def initialize(clause)
+      @clause = clause
+    end
+
+    def +(where_query)
+      if where_query.is_a?(self.class)
+        @clause = [to_s, where_query.to_s.gsub(/^WHERE\s+/, "")].join(" AND ")
+      else
+        raise InvalidQuery("WhereQuery can be mereged only with other WhereQuery")
+      end
+    end
+    alias_method :merge, :+
+
+    private
+
+    def raw_query
+      ["WHERE", clause_as_string]
+    end
+
+    def clause_as_string
+      if @clause.respond_to?(:each_pair)
+        result = []
+        @clause.each_pair do |field_name, value|
+          result << "#{field_name} #{operator_for(value)} #{convert_value(value)}"
+        end
+        result.join(" AND ")
+      else
+        @clause.to_s
+      end
+    end
+
+    def operator_for(value)
+      if value.respond_to?(:keys)
+        OPERATOR_MAPPING[value.keys.first.to_sym]
+      elsif value.respond_to?(:to_a)
+        OPERATOR_MAPPING[:in]
+      else
+        OPERATOR_MAPPING[:eq]
+      end
+    end
+
+    def convert_value(value)
+      if value.respond_to?(:values)
+        attribute_value = value.values.first
+        if value.keys.first == :in
+          convert_value(Array(attribute_value))
+        else
+          convert_value(attribute_value)
+        end
+      elsif value.respond_to?(:to_a)
+        converted_values = value.to_a.map{|value| CQLValue.convert(value)}
+        "(#{converted_values.join(", ")})"
+      else
+        CQLValue.convert(value)
+      end
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/add_query_spec.rb
+++ b/spec/lib/virsandra/queries/add_query_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Virsandra::AddQuery do
+  let(:column_name){ "new_column" }
+  let(:column_type){ nil }
+  subject(:query){ described_class.new(column_name, column_type) }
+
+  describe "#to_s" do
+    subject{ super().to_s }
+
+    it{ should eq("ADD new_column varchar") }
+
+    context "column type specified" do
+      let(:column_type){ "int" }
+
+      it{ should eq("ADD new_column int") }
+    end
+
+    context "column name not specified" do
+      let(:column_name){ nil }
+      it "should raise error" do
+        expect{ subject }.to raise_error(Virsandra::InvalidQuery, "You must specify column name")
+      end
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/alter_query_spec.rb
+++ b/spec/lib/virsandra/queries/alter_query_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Virsandra::AlterQuery do
+  let(:skip_validation){ true }
+  subject(:query){ described_class.new(skip_validation) }
+
+  describe "#to_s" do
+    subject{ super().to_s }
+
+    it{ should eq("ALTER") }
+
+  end
+
+  describe "#table" do
+    subject{ super().table("foo").to_s }
+
+    it{ should eq("ALTER TABLE foo")}
+
+    context "with validation" do
+      let(:skip_validation){ false }
+
+      it "should raise error when table not specified" do
+        expect{ query.to_s }.to raise_error(Virsandra::InvalidQuery, "You must set the table")
+      end
+    end
+  end
+
+  describe "#add" do
+    context "without column type" do
+      subject{ super().table("foo").add(:new_column).to_s }
+
+      it{ should eq("ALTER TABLE foo ADD new_column varchar")}
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/delete_query_spec.rb
+++ b/spec/lib/virsandra/queries/delete_query_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Virsandra::DeleteQuery do
+  subject(:query){ described_class.new }
+
+  its(:to_s){ should eq("DELETE") }
+
+  describe "#from" do
+    it "deletes from given table" do
+      query.from("foo")
+      query.to_s.should eq("DELETE FROM foo")
+    end
+
+    it "allows to use table as alias method" do
+      query.table("foo")
+      query.to_s.should eq("DELETE FROM foo")
+    end
+  end
+
+  describe "#where" do
+    it "adds given criteria to query" do
+      query.from("foo").where(id: "123")
+      query.to_s.should eq("DELETE FROM foo WHERE id = '123'")
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/delete_query_spec.rb
+++ b/spec/lib/virsandra/queries/delete_query_spec.rb
@@ -22,5 +22,13 @@ describe Virsandra::DeleteQuery do
       query.from("foo").where(id: "123")
       query.to_s.should eq("DELETE FROM foo WHERE id = '123'")
     end
+
+    context "called more than once" do
+      it "should join all wheres together" do
+        query.from("foo").where(id: 1)
+        query.where(count: {gt: 4})
+        query.to_s.should eq("DELETE FROM foo WHERE id = 1 AND count > 4")
+      end
+    end
   end
 end

--- a/spec/lib/virsandra/queries/insert_query_spec.rb
+++ b/spec/lib/virsandra/queries/insert_query_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Virsandra::InsertQuery do
+  subject(:query){ described_class.new }
+
+  describe "#into" do
+    subject{ super().into("foo") }
+
+    it "should raise error when values are missing" do
+      expect{ subject.to_s }.to raise_error(Virsandra::InvalidQuery, "You must set values")
+    end
+  end
+
+  describe "#values" do
+    subject{ super().values(column_name: "name") }
+
+    it "should raise error when into is missing" do
+      expect{ subject.to_s }.to raise_error(Virsandra::InvalidQuery, "You must set into")
+    end
+  end
+
+  describe "#to_s" do
+    context "when into is missing" do
+      it "should raise error when into is missing" do
+        expect{ query.to_s }.to raise_error(Virsandra::InvalidQuery, "You must set into")
+      end
+    end
+
+    context "when into and values are set" do
+      subject{ super().into("foo").values(id: 1, date: '2011-11-11').to_s }
+
+      it{ should eq("INSERT INTO foo (id, date) VALUES (1, '2011-11-11')") }
+    end
+  end
+
+end

--- a/spec/lib/virsandra/queries/limit_query_spec.rb
+++ b/spec/lib/virsandra/queries/limit_query_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Virsandra::LimitQuery do
+  let(:number){ 4 }
+  subject{ described_class.new(number) }
+
+  describe "#to_s" do
+    subject{ super().to_s }
+
+    it{ should eq("LIMIT 4")}
+
+    context "when number is less than 1" do
+      let(:number){ 0 }
+
+      it "should raise error" do
+        expect{ subject }.to raise_error(Virsandra::InvalidQuery, "Limit must be positive number")
+      end
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/order_query_spec.rb
+++ b/spec/lib/virsandra/queries/order_query_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Virsandra::OrderQuery do
+  let(:columns){ nil }
+  subject{ described_class.new(columns) }
+
+  describe "#to_s" do
+    subject{ super().to_s }
+
+    it{ should eq("") }
+
+    context "when columns given as string" do
+      let(:columns){ "date DESC" }
+
+      it{ should eq("ORDER BY date DESC")}
+    end
+
+    context "when columns given as hash" do
+      let(:columns){ {date: :asc, user_id: :asc} }
+
+      it{ should eq("ORDER BY date ASC, user_id ASC")}
+    end
+
+    context "when unknown order given" do
+      let(:columns){ {data: :bzz} }
+
+      it "raises an error" do
+        expect{ subject }.to raise_error(Virsandra::InvalidQuery, "Unknown order bzz")
+      end
+    end
+
+  end
+end

--- a/spec/lib/virsandra/queries/select_query_spec.rb
+++ b/spec/lib/virsandra/queries/select_query_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe Virsandra::SelectQuery do
+  let(:columns){ nil }
+  let(:skip_validation){ true }
+  let(:query){ described_class.new(columns, skip_validation) }
+  subject{ query }
+
+  it "uses * as default columns" do
+    subject.to_s.should eq("SELECT *")
+  end
+
+  context "empty array given as columns" do
+    let(:columns){ [] }
+    it "uses * as default columns" do
+      subject.to_s.should eq("SELECT *")
+    end
+  end
+
+  context "when columns are given" do
+    subject{ super().to_s }
+
+    let(:columns){ "id, date" }
+
+    it{ should eq("SELECT id, date")}
+
+    context "when columns are array" do
+      let(:columns){ ['id', 'date'] }
+
+      it{ should eq("SELECT id, date")}
+    end
+  end
+
+  describe "#from" do
+    subject{ super().from("foo").to_s }
+
+    it{ should eq("SELECT * FROM foo")}
+  end
+
+  describe "#where" do
+    subject{ super().from("foo").where(id: 1).to_s }
+
+    it{ should eq("SELECT * FROM foo WHERE id = 1")}
+
+    context "called more than once" do
+      it "should join all wheres together" do
+        query.from("foo").where(id: 1)
+        query.where(count: {gt: 4})
+        query.to_s.should eq("SELECT * FROM foo WHERE id = 1 AND count > 4")
+      end
+    end
+  end
+
+  describe "#order" do
+    subject{ super().from("foo").order(date: "asc").to_s }
+
+    it{ should eq("SELECT * FROM foo ORDER BY date ASC")}
+  end
+
+  describe "#limit" do
+    subject{ super().from("foo").limit(3).to_s }
+
+    it{ should eq("SELECT * FROM foo LIMIT 3")}
+
+    context "when called more than once" do
+      it "uses only last one" do
+        query.from("foo").limit(1)
+        query.limit(4)
+        query.to_s.should eq("SELECT * FROM foo LIMIT 4")
+      end
+    end
+  end
+
+  describe "#reset" do
+    subject{ super().from("foo").where(id: 1) }
+
+    it "should reset query" do
+      subject.to_s.should eq("SELECT * FROM foo WHERE id = 1")
+      subject.reset
+      subject.where(date: "2011-11-11")
+      subject.to_s.should eq("SELECT * FROM foo WHERE date = '2011-11-11'")
+    end
+  end
+
+  describe "#to_s" do
+    let(:skip_validation){ false }
+    it "should validate from existence" do
+      expect{ query.to_s }.to raise_error(Virsandra::InvalidQuery, "You must set from")
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/table_query_spec.rb
+++ b/spec/lib/virsandra/queries/table_query_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Virsandra::TableQuery do
+  describe "#to_s" do
+    it "return given table name" do
+      described_class.new("FROM", "foo").to_s.should eq("FROM foo")
+    end
+
+    it "return empty string when nil given" do
+      described_class.new("FROM",nil).to_s.should eq("")
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/values_query_spec.rb
+++ b/spec/lib/virsandra/queries/values_query_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Virsandra::ValuesQuery do
+  let(:values){ {} }
+  subject(:query){ described_class.new(values) }
+
+  describe "#to_s" do
+    subject{ super().to_s }
+
+    it{ should eq("") }
+
+    context "when values given" do
+      let(:values){ {id: 1, date: '2011-11-11'} }
+
+      it{ should eq("(id, date) VALUES (1, '2011-11-11')")}
+
+      it "should convert each value" do
+        Virsandra::CQLValue.should_receive(:convert).twice
+        subject
+      end
+    end
+
+    context "when any value is nil" do
+      let(:values){ {id: 1, date: nil} }
+
+      it{ should eq("(id) VALUES (1)")}
+    end
+
+    context "when all values are nil" do
+      let(:values){ {id: nil, date: nil} }
+
+      it{ should eq("")}
+    end
+  end
+end

--- a/spec/lib/virsandra/queries/values_query_spec.rb
+++ b/spec/lib/virsandra/queries/values_query_spec.rb
@@ -31,5 +31,11 @@ describe Virsandra::ValuesQuery do
 
       it{ should eq("")}
     end
+
+    context "when values is something else than hash" do
+      let(:values){ [] }
+
+      it{ should eq("") }
+    end
   end
 end

--- a/spec/lib/virsandra/queries/where_query_spec.rb
+++ b/spec/lib/virsandra/queries/where_query_spec.rb
@@ -11,6 +11,10 @@ describe Virsandra::WhereQuery do
     it "merge both where clauses with AND" do
       (query + other_query).should eq("WHERE id IN (1, 2) AND count <= 4")
     end
+
+    it "should raise error when something else than WhereQuery is given" do
+      expect{ query + 1}.to raise_error(Virsandra::InvalidQuery, "WhereQuery can be mereged only with other WhereQuery")
+    end
   end
 
   describe "#to_s" do

--- a/spec/lib/virsandra/queries/where_query_spec.rb
+++ b/spec/lib/virsandra/queries/where_query_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Virsandra::WhereQuery do
+  subject(:query){ described_class.new(clause) }
+
+  describe "#+" do
+    let(:clause){ {id: [1,2]} }
+    let(:other_query){ described_class.new(other_clause) }
+    let(:other_clause){ {count: {lt_or_eq: 4}} }
+
+    it "merge both where clauses with AND" do
+      (query + other_query).should eq("WHERE id IN (1, 2) AND count <= 4")
+    end
+  end
+
+  describe "#to_s" do
+    subject{ super().to_s }
+
+    context "when clause given as string" do
+      let(:clause){ "id='1' AND count=6" }
+
+      it{ should eq("WHERE id='1' AND count=6")}
+    end
+
+    context "when clause given as hash" do
+      let(:clause){ {id: '1', count: 6} }
+
+      it{ should eq("WHERE id = '1' AND count = 6")}
+
+      it "should convert each value" do
+        Virsandra::CQLValue.should_receive(:convert).twice
+        subject
+      end
+    end
+
+
+    described_class::OPERATOR_MAPPING.reject{|key,value| key == :in}.each do |operator_name, operator|
+      context "when any clause value given as hash" do
+        let(:clause){ {id: '1', count: Hash[operator_name, 6]} }
+
+        it{ should eq("WHERE id = '1' AND count #{operator} 6") }
+
+        it "should convert each value" do
+          Virsandra::CQLValue.should_receive(:convert).twice
+          subject
+        end
+      end
+    end
+
+    context "when any clause value given as hash and hash key is :in" do
+      let(:clause){ {id: '1', count: {:in => 6}} }
+
+      it{ should eq("WHERE id = '1' AND count IN (6)")}
+
+      it "should convert each value" do
+        Virsandra::CQLValue.should_receive(:convert).twice
+        subject
+      end
+    end
+
+    context "when any clause value given as array" do
+      let(:clause){ {id: '1', count: [2,3]} }
+
+      it{ should eq("WHERE id = '1' AND count IN (2, 3)") }
+
+      it "should convert each value" do
+        Virsandra::CQLValue.should_receive(:convert).exactly(3).times
+        subject
+      end
+    end
+  end
+end

--- a/spec/lib/virsandra/query_spec.rb
+++ b/spec/lib/virsandra/query_spec.rb
@@ -2,45 +2,12 @@ require 'spec_helper'
 
 describe Virsandra::Query do
 
-  it "has class methods to create instances for each method" do
-    Virsandra::Query.should_receive(:new).with(:select, "*")
-    Virsandra::Query.select
-
-    Virsandra::Query.should_receive(:new).with(:select, "a, b, c, d")
-    Virsandra::Query.select(:a, :b, :c, :d)
-
-    Virsandra::Query.should_receive(:new).with(:insert)
-    Virsandra::Query.insert
-
-    Virsandra::Query.should_receive(:new).with(:delete)
-    Virsandra::Query.delete
-
-    Virsandra::Query.should_receive(:new).with(:alter)
-    Virsandra::Query.alter
-  end
-
-  it "sets the table and statment type on initialization" do
-    Virsandra::Query.any_instance.should_receive(:start_query)
-
-    query = Virsandra::Query.new(:insert)
-    query.statement.should == :insert
-  end
-
-  it "starting building the given statement type" do
-    q = Virsandra::Query.new(:select, '*')
-    q.to_s.should == "SELECT * FROM"
-  end
-
-  it "raises an error if statement is not supported" do
-    expect { Virsandra::Query.new(:junk) }.to raise_error { ArgumentError }
-  end
-
   it "adds a from method" do
     q = Virsandra::Query.select.from(:foo)
     q.to_s.should == "SELECT * FROM foo"
 
-    q = Virsandra::Query.insert.into(:foo)
-    q.to_s.should == "INSERT INTO foo"
+    q = Virsandra::Query.insert.into(:foo).values(id: 1)
+    q.to_s.should == "INSERT INTO foo (id) VALUES (1)"
 
     q = Virsandra::Query.delete.from(:foo)
     q.to_s.should == "DELETE FROM foo"
@@ -50,22 +17,24 @@ describe Virsandra::Query do
   end
 
   it "can change the table" do
-    q = Virsandra::Query.insert.into(:foo)
+    q = Virsandra::Query.insert.into(:foo).values(id: 1)
 
     q.into(:bar)
-    q.to_s.should == "INSERT INTO bar"
+    q.to_s.should == "INSERT INTO bar (id) VALUES (1)"
   end
 
-  it "adds a where clause when appropirate" do
+  it "adds a where clause when appropriate" do
     q = Virsandra::Query.select.from(:foo).where(id: 'Funky', location: 'town')
     q.to_s.should == "SELECT * FROM foo WHERE id = 'Funky' AND location = 'town'"
 
+    q.reset
     q.where(can: "change options")
     q.to_s.should == "SELECT * FROM foo WHERE can = 'change options'"
 
     uuid = SimpleUUID::UUID.new
     uuid.stub(to_guid: 'i-am-a-guid')
 
+    q.reset
     q.where(cid: uuid, nummer: 123)
     q.to_s.should == "SELECT * FROM foo WHERE cid = i-am-a-guid AND nummer = 123"
 
@@ -122,11 +91,11 @@ describe Virsandra::Query do
 
   it "can fetch a raw query" do
     cql = "SELECT * FROM cities WHERE town = 'funky'"
-    query = Virsandra::Query.new(cql)
+    query = Virsandra::Query.new
 
     Virsandra.should_receive(:execute).with(cql)
 
-    query.fetch
+    query.fetch(cql)
   end
 
 end

--- a/spec/lib/virsandra/query_spec.rb
+++ b/spec/lib/virsandra/query_spec.rb
@@ -2,6 +2,17 @@ require 'spec_helper'
 
 describe Virsandra::Query do
 
+  [:from, :table, :into, :where, :order, :limit, :add, :values].each do |method_name|
+    it "should raise error when #{method_name} called" do
+      expect{ described_class.new.send(method_name) }.to raise_error(Virsandra::InvalidQuery  )
+    end
+  end
+
+  it "should return empty hash when can't fetch hash from results" do
+    Virsandra.stub(:execute => double("row", :fetch_hash => nil))
+    described_class.new.fetch.should eq({})
+  end
+
   it "adds a from method" do
     q = Virsandra::Query.select.from(:foo)
     q.to_s.should == "SELECT * FROM foo"

--- a/spec/lib/virsandra_spec.rb
+++ b/spec/lib/virsandra_spec.rb
@@ -45,7 +45,7 @@ describe Virsandra do
       servers: '127.0.0.1:9160',
       cql_version: '3.0.0',
       consistency: :quorum,
-      thrift_options: {retries: 5, connect_timeout: 1, timeout: 1},
+      thrift_options: {retries: 5, connect_timeout: 10, timeout: 10},
       keyspace: nil
     }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,9 @@
 require 'bundler/setup'
 
-# require 'coveralls'
-# Coveralls.wear!
+require 'coveralls'
+Coveralls.wear!
 
 require 'simplecov'
-SimpleCov.configure do
-  add_filter '/test/'
-  add_filter '/features/'
-  add_filter '/spec/'
-
-  add_group 'Libraries', 'lib'
-end
-SimpleCov.start
 SimpleCov.start
 
 require 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,17 @@
 require 'bundler/setup'
 
-require 'coveralls'
-Coveralls.wear!
+# require 'coveralls'
+# Coveralls.wear!
 
 require 'simplecov'
+SimpleCov.configure do
+  add_filter '/test/'
+  add_filter '/features/'
+  add_filter '/spec/'
+
+  add_group 'Libraries', 'lib'
+end
+SimpleCov.start
 SimpleCov.start
 
 require 'rspec'


### PR DESCRIPTION
I've changed Virsandra::Query class, to make it cleaner and now it is used as superclass for all other query classes. Also limit and order queries added, but not yet used in ModelQuery class. SelectQuery now works a little bit different than before, because now it is possible to chain together more than one where clause and they will be joined together with " AND ", but if also I made old functionality work by adding "reset" method to select query.
I fixed travis config based on this opened issue https://github.com/travis-ci/travis-ci/issues/1053
