### PR TITLE
Replace cassandra-cql with cql-rb (switch to binary protocol)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in virsandra.gemspec
 
 gem 'coveralls', require: false
-gem "cassandra-cql", :git => "git://github.com/ottbot/cassandra-cql", :branch => "1.2-set-consistency"
+
 
 gemspec

--- a/lib/virsandra.rb
+++ b/lib/virsandra.rb
@@ -3,6 +3,7 @@ require 'cql'
 require 'simple_uuid'
 require 'forwardable'
 
+
 require "virsandra/version"
 require 'virsandra/errors'
 require "virsandra/configuration"
@@ -10,10 +11,6 @@ require "virsandra/configuration"
 module Virsandra
 
   class << self
-    extend Forwardable
-    def_delegator :connection, :execute
-    def_delegators :configuration, :reset!, *Virsandra::Configuration::OPTIONS.map{ |method_name| [method_name, :"#{method_name}="] }.flatten
-
     def configuration
       Thread.current[:configuration] ||= Virsandra::Configuration.new
     end
@@ -24,6 +21,7 @@ module Virsandra
 
     def connection
       if dirty?
+        disconnect!
         Thread.current[:connection] = Virsandra::Connection.new(configuration)
         configuration.accept_changes
       end
@@ -31,11 +29,46 @@ module Virsandra
     end
 
     def disconnect!
-      if Thread.current[:connection].respond_to?(:dissconnect!)
+      if Thread.current[:connection].respond_to?(:disconnect!)
         Thread.current[:connection].disconnect!
       end
       Thread.current[:connection] = nil
+    end
+
+    def reset!
+      configuration.reset!
+    end
+
+    def reset_configuration!
       Thread.current[:configuration] = nil
+    end
+
+    def consistency
+      configuration.consistency
+    end
+
+    def keyspace
+      configuration.keyspace
+    end
+
+    def servers
+      configuration.servers
+    end
+
+    def consistency=(value)
+      configuration.consistency = value
+    end
+
+    def keyspace=(value)
+      configuration.keyspace = value
+    end
+
+    def servers=(value)
+      configuration.servers = value
+    end
+
+    def execute(query)
+      connection.execute(query)
     end
 
     private

--- a/lib/virsandra.rb
+++ b/lib/virsandra.rb
@@ -1,38 +1,56 @@
-require "virtus"
-require "cql"
-require "simple_uuid"
+require 'virtus'
+require 'cql'
+require 'simple_uuid'
+require 'forwardable'
 
 require "virsandra/version"
+require 'virsandra/errors'
 require "virsandra/configuration"
+
+module Virsandra
+
+  class << self
+    extend Forwardable
+    def_delegator :connection, :execute
+    def_delegators :configuration, :reset!, *Virsandra::Configuration::OPTIONS.map{ |method_name| [method_name, :"#{method_name}="] }.flatten
+
+    def configuration
+      Thread.current[:configuration] ||= Virsandra::Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
+
+    def connection
+      if dirty?
+        Thread.current[:connection] = Virsandra::Connection.new(configuration)
+        configuration.accept_changes
+      end
+      Thread.current[:connection]
+    end
+
+    def disconnect!
+      if Thread.current[:connection].respond_to?(:dissconnect!)
+        Thread.current[:connection].disconnect!
+      end
+      Thread.current[:connection] = nil
+      Thread.current[:configuration] = nil
+    end
+
+    private
+
+    def dirty?
+      Thread.current[:connection].nil? || configuration.changed?
+    end
+
+  end
+end
+
+
+
 require "virsandra/connection"
 require "virsandra/cql_value"
 require "virsandra/query"
 require "virsandra/model_query"
 require "virsandra/model"
-
-module Virsandra
-
-  extend Configuration
-
-  class << self
-    extend Forwardable
-    def_delegator :connection, :execute
-
-    def connection
-      @connection = Connection.new(self) if dirty?
-      @connection
-    end
-
-    def dirty?
-      return true if @connection.nil?
-      @connection.options != self.to_hash
-    end
-
-    def disconnect!
-      if @connection && @connection.handle
-        @connection.disconnect!
-      end
-      @connection = nil
-    end
-  end
-end

--- a/lib/virsandra.rb
+++ b/lib/virsandra.rb
@@ -1,5 +1,6 @@
 require "virtus"
-require "cassandra-cql/1.2"
+require "cql"
+require "simple_uuid"
 
 require "virsandra/version"
 require "virsandra/configuration"

--- a/lib/virsandra/configuration.rb
+++ b/lib/virsandra/configuration.rb
@@ -6,9 +6,7 @@ module Virsandra
     OPTIONS = [
       :keyspace,
       :servers,
-      :thrift_options,
       :consistency,
-      :cql_version
     ]
 
     attr_accessor *OPTIONS
@@ -19,9 +17,7 @@ module Virsandra
 
     def reset!
       self.servers = '127.0.0.1:9160'
-      self.cql_version = '3.0.0'
       self.consistency = :quorum
-      self.thrift_options = {retries: 5, connect_timeout: 10, timeout: 10}
       self.keyspace = nil
     end
 

--- a/lib/virsandra/configuration.rb
+++ b/lib/virsandra/configuration.rb
@@ -16,7 +16,7 @@ module Virsandra
     end
 
     def reset!
-      self.servers = '127.0.0.1:9160'
+      self.servers = '127.0.0.1:9042'
       self.consistency = :quorum
       self.keyspace = nil
     end

--- a/lib/virsandra/configuration.rb
+++ b/lib/virsandra/configuration.rb
@@ -1,28 +1,26 @@
 module Virsandra
-  class ConfigurationError < Exception; ; end
-
-  module Configuration
-
+  class Configuration
     OPTIONS = [
+      :consistency,
       :keyspace,
       :servers,
-      :consistency,
-    ]
+    ].freeze
+
+    DEFAULT_OPTION_VALUES = {
+      servers: "127.0.0.1",
+      consistency: :quorum
+    }.freeze
 
     attr_accessor *OPTIONS
 
-    def self.extended(base)
-      base.reset!
+    def initialize(options = {})
+      reset!
+      use_options(options || {})
+      accept_changes
     end
 
     def reset!
-      self.servers = '127.0.0.1:9042'
-      self.consistency = :quorum
-      self.keyspace = nil
-    end
-
-    def configure
-      yield self
+      use_options(DEFAULT_OPTION_VALUES)
     end
 
     def validate!
@@ -31,12 +29,33 @@ module Virsandra
       end
     end
 
+    def accept_changes
+      @old_hash = hash
+    end
+
     def to_hash
-      OPTIONS.reduce({}) do |settings, option|
-        settings[option] = self.send(option)
-        settings
+      OPTIONS.each_with_object({}) do |attr, settings|
+        settings[attr] = send(attr)
       end
     end
 
+    def changed?
+      hash != @old_hash
+    end
+
+    def hash
+      to_hash.hash
+    end
+
+    private
+
+    def use_options(options)
+      options.each do |key, value|
+        if OPTIONS.include?(key)
+          send(:"#{key}=", value)
+        end
+      end
+    end
   end
+
 end

--- a/lib/virsandra/connection.rb
+++ b/lib/virsandra/connection.rb
@@ -13,11 +13,13 @@ module Virsandra
     end
 
     def connect!
-      cql_options = @options.select {|k| [:keyspace, :cql_version, :consistency].include?(k) }
+      @handle = Cql::Client.connect(hosts: @options[:servers])
+      @handle.use(@options[:keyspace])
+      @handle
+    end
 
-      @handle = CassandraCQL::Database.new(@options[:servers],
-                                           cql_options,
-                                           @options[:thrift_options])
+    def disconnect!
+      @handle.close
     end
 
     # Delegate to CassandraCQL::Database handle

--- a/lib/virsandra/connection.rb
+++ b/lib/virsandra/connection.rb
@@ -3,23 +3,26 @@ module Virsandra
 
     extend Forwardable
 
-    attr_reader :handle, :options
+    attr_reader :handle, :config
 
-    def initialize(options)
-      options.validate!
-      @options = options.to_hash
-
+    def initialize(config)
+      @config = config
+      config.validate!
       connect!
     end
 
     def connect!
-      @handle = Cql::Client.connect(hosts: @options[:servers])
-      @handle.use(@options[:keyspace])
+      @handle = Cql::Client.connect(hosts: @config.servers)
+      @handle.use(@config.keyspace)
       @handle
     end
 
     def disconnect!
       @handle.close
+    end
+
+    def execute(query, consistency = nil)
+      @handle.execute(query, consistency || config.consistency)
     end
 
     # Delegate to CassandraCQL::Database handle

--- a/lib/virsandra/cql_value.rb
+++ b/lib/virsandra/cql_value.rb
@@ -12,17 +12,22 @@ module Virsandra
     end
 
     def to_cql
-      case value
-      when Numeric
-        value.to_s
-      when SimpleUUID::UUID
+      if value.respond_to?(:to_guid)
         value.to_guid
-      else
+      elsif should_escape?(value)
         "'#{escape(value)}'"
+      else
+        value.to_s
       end
     end
 
     private
+
+    def should_escape?(value)
+      !![String, Symbol, Time, Date].detect do |klass|
+        value.is_a?(klass)
+      end
+    end
 
     def escape(str)
       str = str.to_s.gsub(/'/,"''")

--- a/lib/virsandra/errors.rb
+++ b/lib/virsandra/errors.rb
@@ -1,0 +1,3 @@
+module Virsandra
+  class ConfigurationError < ArgumentError; ; end
+end

--- a/lib/virsandra/model_query.rb
+++ b/lib/virsandra/model_query.rb
@@ -40,7 +40,8 @@ module Virsandra
 
     def query_enumerator(query)
       Enumerator.new do |yielder|
-        query.execute.each do |row|
+        rows = query.execute
+        rows.each do |row|
           record = @model.new(row.to_hash)
           yielder.yield record
         end

--- a/lib/virsandra/query.rb
+++ b/lib/virsandra/query.rb
@@ -56,6 +56,7 @@ module Virsandra
     end
 
     def execute
+
       @row = Virsandra.execute(self.to_s)
     end
 

--- a/lib/virsandra/query.rb
+++ b/lib/virsandra/query.rb
@@ -72,7 +72,7 @@ module Virsandra
     end
 
     def fetch_with_symbolized_keys
-      row_hash = @row && @row.fetch_hash
+      row_hash = @row && @row.first
       return {} unless row_hash
 
       Hash[row_hash.map{|(k,v)| [k.to_sym,v]}]

--- a/lib/virsandra/version.rb
+++ b/lib/virsandra/version.rb
@@ -1,3 +1,3 @@
 module Virsandra
-  VERSION = "0.0.1"
+  VERSION = "0.5.0"
 end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+TEST_KEYSPACE = "virtest"
+
+module IntegrationTestHelper
+  def create_keyspace
+    Virsandra.keyspace = 'system'
+    Virsandra.execute("CREATE KEYSPACE #{TEST_KEYSPACE} WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+    Virsandra.reset!
+  end
+
+  def create_companies_table
+    cql = <<-CQL
+       CREATE TABLE companies (
+          id uuid,
+          name text,
+          score int,
+          founder text,
+          founded int,
+          PRIMARY KEY (id, score))
+    CQL
+    Virsandra.keyspace = TEST_KEYSPACE
+    Virsandra.execute(cql)
+  end
+
+  def drop_keyspace
+    Virsandra.reset!
+    Virsandra.keyspace = 'system'
+    Virsandra.execute("DROP KEYSPACE #{TEST_KEYSPACE}")
+  end
+
+  def build_up
+    begin
+      create_keyspace
+      create_companies_table
+    rescue Cql::QueryError
+      drop_keyspace
+
+      if defined?(retried)
+        raise $!
+      else
+        retried = true
+        retry
+      end
+    end
+  end
+end
+
+
+
+RSpec.configure do |config|
+
+  config.include(IntegrationTestHelper)
+
+  config.before do
+    if example.metadata[:integration]
+      build_up
+      Virsandra.reset!
+      Virsandra.keyspace = TEST_KEYSPACE
+    end
+  end
+end

--- a/spec/integration/virsandra_spec.rb
+++ b/spec/integration/virsandra_spec.rb
@@ -7,6 +7,7 @@ describe "Virsandra", integration: true do
   end
 
   it "allows to disconnect" do
-    expect{ Virsandra.disconnect! }.not_to raise_error
+    Virsandra.connection.should_receive(:disconnect!).and_call_original
+    Virsandra.disconnect!
   end
 end

--- a/spec/integration/virsandra_spec.rb
+++ b/spec/integration/virsandra_spec.rb
@@ -1,0 +1,12 @@
+require 'feature_helper'
+
+describe "Virsandra", integration: true do
+
+  it "return connection to server" do
+    Virsandra.connection.should_not be_nil
+  end
+
+  it "allows to disconnect" do
+    expect{ Virsandra.disconnect! }.not_to raise_error
+  end
+end

--- a/spec/lib/virsandra/configuration_spec.rb
+++ b/spec/lib/virsandra/configuration_spec.rb
@@ -8,7 +8,7 @@ describe Virsandra::Configuration do
   its(:consistency){ should eq(:quorum) }
   its(:keyspace){ should be_nil }
 
-  it "should usge given values over default ones" do
+  it "uses given values over default ones" do
     described_class.new(consistency: :one).consistency.should eq(:one)
   end
 
@@ -22,7 +22,7 @@ describe Virsandra::Configuration do
     context "no servers" do
       let(:given_options){ {servers: nil} }
 
-      it "should rase an error" do
+      it "should raise an error" do
         expect{ config.validate! }.to raise_error(Virsandra::ConfigurationError)
       end
     end

--- a/spec/lib/virsandra/configuration_spec.rb
+++ b/spec/lib/virsandra/configuration_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Virsandra::Configuration do
+  subject(:config){ described_class.new(given_options) }
+  let(:given_options){ {} }
+
+  its(:servers){ should eq("127.0.0.1") }
+  its(:consistency){ should eq(:quorum) }
+  its(:keyspace){ should be_nil }
+
+  it "should usge given values over default ones" do
+    described_class.new(consistency: :one).consistency.should eq(:one)
+  end
+
+  describe "validate!" do
+    context "no keyspace" do
+      it "should raise an error" do
+        expect{ config.validate! }.to raise_error(Virsandra::ConfigurationError)
+      end
+    end
+
+    context "no servers" do
+      let(:given_options){ {servers: nil} }
+
+      it "should rase an error" do
+        expect{ config.validate! }.to raise_error(Virsandra::ConfigurationError)
+      end
+    end
+  end
+
+  describe "#reset!" do
+    let(:given_options){ {keyspace: :my_keyspace} }
+
+    it "reset options to default ones" do
+      config.reset!
+      config.keyspace.should == :my_keyspace
+    end
+  end
+
+  describe "to_hash" do
+    it "returns all options as a hash" do
+      config.to_hash.should eq({
+        consistency: :quorum,
+        keyspace: nil,
+        servers: "127.0.0.1"
+      })
+    end
+  end
+
+  describe "changed?" do
+    it "should be changed when option attribute value changes" do
+      config.changed?.should be_false
+      config.keyspace = :other
+      config.changed?.should be_true
+    end
+
+    it "stops being changed when changes are accepted" do
+      config.changed?.should be_false
+      config.keyspace = :other
+      config.changed?.should be_true
+      config.accept_changes
+      config.changed?.should be_false
+    end
+  end
+
+end

--- a/spec/lib/virsandra/connection_spec.rb
+++ b/spec/lib/virsandra/connection_spec.rb
@@ -11,7 +11,7 @@ describe Virsandra::Connection do
   end
 
   it "obtains a db connection" do
-    connection.handle.should be_a CassandraCQL::Database
+    connection.handle.should be_a Cql::Client::SynchronousClient
   end
 
   it "delegates to the cassandra handle" do

--- a/spec/lib/virsandra/model_spec.rb
+++ b/spec/lib/virsandra/model_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'feature_helper'
 
 class Company
   include Virsandra::Model
@@ -14,7 +14,7 @@ class Company
 end
 
 
-describe Virsandra::Model do
+describe Virsandra::Model, integration: true do
 
   let(:id) { SimpleUUID::UUID.new }
 

--- a/spec/lib/virsandra/query_spec.rb
+++ b/spec/lib/virsandra/query_spec.rb
@@ -9,7 +9,7 @@ describe Virsandra::Query do
   end
 
   it "should return empty hash when can't fetch hash from results" do
-    Virsandra.stub(:execute => double("row", :fetch_hash => nil))
+    Virsandra.stub(:execute => double("row", :first => nil))
     described_class.new.fetch.should eq({})
   end
 

--- a/spec/lib/virsandra_spec.rb
+++ b/spec/lib/virsandra_spec.rb
@@ -43,9 +43,7 @@ describe Virsandra do
 
     defaults = {
       servers: '127.0.0.1:9160',
-      cql_version: '3.0.0',
       consistency: :quorum,
-      thrift_options: {retries: 5, connect_timeout: 10, timeout: 10},
       keyspace: nil
     }
 
@@ -65,12 +63,10 @@ describe Virsandra do
   end
 
   it "reconnects if dirty" do
-    CassandraCQL::Database.stub(:new)
-
     Virsandra::Connection.should_receive(:new).twice.and_call_original
     Virsandra.connection
 
-    Virsandra.keyspace = 'foo'
+    Virsandra.keyspace = 'system'
     Virsandra.connection
     Virsandra.connection
   end

--- a/spec/lib/virsandra_spec.rb
+++ b/spec/lib/virsandra_spec.rb
@@ -42,7 +42,7 @@ describe Virsandra do
     Virsandra.reset!
 
     defaults = {
-      servers: '127.0.0.1:9160',
+      servers: '127.0.0.1:9042',
       consistency: :quorum,
       keyspace: nil
     }

--- a/spec/lib/virsandra_spec.rb
+++ b/spec/lib/virsandra_spec.rb
@@ -1,80 +1,90 @@
 require 'spec_helper'
 
 describe Virsandra do
+  let(:config){ double("config", :changed? => false, :accept_changes => nil) }
+  let(:connection){ double("connection") }
+  subject{ described_class }
 
-  before { Virsandra.disconnect! }
-
-  it "delegates execute to the connection handle" do
-    Virsandra.should respond_to :execute
+  before do
+    described_class::Connection.stub(new: connection)
+    described_class::Configuration.stub(new: config)
+    described_class.disconnect!
   end
 
-  it "has a connection" do
-    Virsandra::Connection.should_receive(:new).with(Virsandra).and_call_original
-    Virsandra.connection.should be_a Virsandra::Connection
+  after do
+    described_class::Connection.unstub(:new)
+    described_class::Configuration.unstub(:new)
+    described_class.disconnect!
   end
 
-  it "can be configured via block" do
-    Virsandra.configure do |c|
-      c.keyspace = 'foo'
+  describe "#execute" do
+    it "should be delegated to connection" do
+      connection.should_receive(:execute)
+      described_class.execute
+    end
+  end
+
+  describe "#connection" do
+    it "should pass configuration to connection" do
+      described_class::Connection.should_receive(:new).with(config).once
+      described_class.connection
+      described_class.connection.should eq(connection)
     end
 
-    Virsandra.keyspace.should == 'foo'
+    it "should create new connection when configuration has been changed" do
+      described_class::Connection.should_receive(:new).twice
+      described_class.connection
+      config.stub(:changed? => true)
+      described_class.connection
+    end
+
+    it "should have connection for each thread" do
+      described_class::Connection.should_receive(:new).twice
+      threads = []
+      threads << Thread.new{ described_class.connection }
+      threads << Thread.new{ described_class.connection }
+      threads.map(&:join)
+    end
   end
 
-  it "resets to default settings" do
-    Virsandra.keyspace = 'foo'
-    Virsandra.reset!
-    Virsandra.keyspace.should be_nil
+
+  describe "#configuration" do
+    it "returns configuration" do
+      described_class.configuration.should eq(config)
+    end
+
+    it "should have configuration for every thread" do
+      described_class::Configuration.should_receive(:new).twice
+      threads = []
+      threads << Thread.new{ described_class.configuration }
+      threads << Thread.new{ described_class.configuration }
+      threads.map(&:join)
+    end
   end
 
-  it "is invalid without a keyspace" do
-    Virsandra.keyspace = nil
-    expect { Virsandra.validate! }.to raise_error(Virsandra::ConfigurationError)
+  describe "#configure" do
+    it "should yield to block if block given" do
+      expect{|b| described_class.configure(&b) }.to yield_with_args(config)
+    end
   end
 
-  it "is invalid without a server" do
-    Virsandra.keyspace = 'foo'
-    Virsandra.servers = nil
-    expect { Virsandra.validate! }.to raise_error(Virsandra::ConfigurationError)
+  describe "delegation to configuration" do
+    [:keyspace, :keyspace=, :servers, :servers=, :consistency, :consistency=, :reset!].each do |method_name|
+      it "should deletege #{method_name} to configuration" do
+        config.should_receive(method_name).any_number_of_times
+        described_class.send(method_name)
+      end
+    end
   end
 
-  it "hashifies the settings" do
-    Virsandra.reset!
-
-    defaults = {
-      servers: '127.0.0.1:9042',
-      consistency: :quorum,
-      keyspace: nil
-    }
-
-    Virsandra.to_hash.should == defaults
+  describe "#dissconnect!" do
+    it "should dissconnect" do
+      described_class.connection
+      connection.stub(respond_to?: true)
+      connection.should_receive(:disconnect!)
+      described_class.disconnect!
+    end
   end
 
-  it "can tell if connection settings are dirty" do
-    Virsandra.connection
-    Virsandra.keyspace = 'funky'
-    Virsandra.should be_dirty
-  end
-
-  it "only connects once" do
-    Virsandra::Connection.should_receive(:new).once.and_call_original
-    Virsandra.connection
-    Virsandra.connection
-  end
-
-  it "reconnects if dirty" do
-    Virsandra::Connection.should_receive(:new).twice.and_call_original
-    Virsandra.connection
-
-    Virsandra.keyspace = 'system'
-    Virsandra.connection
-    Virsandra.connection
-  end
-
-  it "disconnects cassandra" do
-    Virsandra.connection #reestablish conn for the test
-    Virsandra.connection.should_receive(:disconnect!)
-    Virsandra.disconnect!
-  end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,69 +9,11 @@ SimpleCov.start
 require 'rspec'
 require 'virsandra'
 
-
-TEST_KEYSPACE = "virtest"
-
-def create_keyspace
-  Virsandra.keyspace = 'system'
-  Virsandra.execute("CREATE KEYSPACE #{TEST_KEYSPACE} WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}")
-  Virsandra.reset!
-end
-
-def create_companies_table
-  cql = <<-CQL
-     CREATE TABLE companies (
-        id uuid,
-        name text,
-        score int,
-        founder text,
-        founded int,
-        PRIMARY KEY (id, score))
-  CQL
-  Virsandra.keyspace = TEST_KEYSPACE
-  Virsandra.execute(cql)
-end
-
-def drop_keyspace
-  Virsandra.reset!
-  Virsandra.keyspace = 'system'
-  Virsandra.execute("DROP KEYSPACE #{TEST_KEYSPACE}")
-end
-
-def build_up
-  begin
-    create_keyspace
-    create_companies_table
-  rescue Cql::QueryError
-    drop_keyspace
-
-    if defined?(retried)
-      raise $!
-    else
-      retried = true
-      retry
-    end
-  end
-end
-
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 
-  config.before(:suite) do
-    build_up
-  end
-
-  config.before do
-    Virsandra.reset!
-    Virsandra.keyspace = TEST_KEYSPACE
-  end
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
   config.order = 'random'
-
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ def build_up
   begin
     create_keyspace
     create_companies_table
-  rescue CassandraCQL::Error::InvalidRequestException
+  rescue Cql::QueryError
     drop_keyspace
 
     if defined?(retried)

--- a/virsandra.gemspec
+++ b/virsandra.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   #gem.add_dependency "cassandra-cql", #WHEN IT SUPPORTS CQL3
   gem.add_dependency "virtus", ">= 0.5.4"
+  gem.add_dependency "cql-rb", ">= 1.0.2"
   gem.add_dependency "simple_uuid", ">= 0.3.0"
 
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/virsandra.gemspec
+++ b/virsandra.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |gem|
 
 
   #gem.add_dependency "cassandra-cql", #WHEN IT SUPPORTS CQL3
-  gem.add_dependency "virtus", ">= 0.5.4"
-  gem.add_dependency "cql-rb", ">= 1.0.2"
-  gem.add_dependency "simple_uuid", ">= 0.3.0"
+  gem.add_dependency "virtus", "~> 0.5.4"
+  gem.add_dependency "cql-rb", "~> 1.0.4"
+  gem.add_dependency "simple_uuid", "~> 0.3.0"
 
-  gem.add_development_dependency "rake", ">= 0.9.2"
-  gem.add_development_dependency "rspec", ">= 2.10.0"
-  gem.add_development_dependency "simplecov"
+  gem.add_development_dependency "rake", "~>10.0.4"
+  gem.add_development_dependency "rspec", "~>2.13.0"
+  gem.add_development_dependency "simplecov", "~>0.7.1"
 end

--- a/virsandra.gemspec
+++ b/virsandra.gemspec
@@ -10,16 +10,21 @@ Gem::Specification.new do |gem|
   gem.email         = ["rob@servermilk.com"]
   gem.description   = %q{Cassandra CQL3 persistence for Virtus extended classes}
   gem.summary       = %q{Easily store models defined with Virtus in Cassandra using CQL3}
-  gem.homepage      = ""
-
-  gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.homepage      = "https://github.com/ottbot/virsandra"
+  
+  gem.licenses      = ["MIT"]
+  gem.files         =  Dir["{lib,vendor}/**/*"] + ["Rakefile", "README.md"]
+  gem.test_files    = Dir["{spec}/**/*"]
+  
+  gem.extra_rdoc_files = [
+    "LICENSE.txt",
+    "README.md"
+  ]
   gem.require_paths = ["lib"]
-
+ 
 
   #gem.add_dependency "cassandra-cql", #WHEN IT SUPPORTS CQL3
-  gem.add_dependency "virtus", "~> 0.5.4"
+  gem.add_dependency "virtus", "~> 0.5.5"
   gem.add_dependency "cql-rb", "~> 1.0.4"
   gem.add_dependency "simple_uuid", "~> 0.3.0"
 


### PR DESCRIPTION
As suggested by #6 , this replaces the thirft-based CassandraCQL with Cql::Client, allowing the cassandra connection to use the binary protocol.

I've not tested this outside of making the current test suite pass.
