### PR TITLE
Added credentials to Cql::Client connection

### DIFF
--- a/lib/virsandra.rb
+++ b/lib/virsandra.rb
@@ -73,6 +73,14 @@ module Virsandra
       configuration.servers = value
     end
 
+    def username=(value)
+      configuration.credentials[:username] = value
+    end
+
+    def password=(value)
+      configuration.credentials[:password] = value
+    end
+
     def execute(query)
       connection.execute(query)
     end

--- a/lib/virsandra/configuration.rb
+++ b/lib/virsandra/configuration.rb
@@ -4,11 +4,13 @@ module Virsandra
       :consistency,
       :keyspace,
       :servers,
+      :credentials,
     ].freeze
 
     DEFAULT_OPTION_VALUES = {
       servers: "127.0.0.1",
-      consistency: :quorum
+      consistency: :quorum,
+      credentials: {}
     }.freeze
 
     attr_accessor *OPTIONS

--- a/lib/virsandra/connection.rb
+++ b/lib/virsandra/connection.rb
@@ -12,7 +12,11 @@ module Virsandra
     end
 
     def connect!
-      @handle = Cql::Client.connect(hosts: [@config.servers].flatten)
+      params = {hosts: [@config.servers].flatten}
+      if @config.credentials.any?
+        params.merge!( credentials: @config.credentials )
+      end
+      @handle = Cql::Client.connect( params )
       @handle.use(@config.keyspace)
       @handle
     end

--- a/lib/virsandra/tasks.rb
+++ b/lib/virsandra/tasks.rb
@@ -9,6 +9,9 @@ namespace :virsandra do
       else
         {}
       end
+      if ENV['USERNAME'] && ENV['PASSWORD']
+        config_options.merge!( credentials: {username: ENV['USERNAME'], password: ENV['PASSWORD']})
+      end
       keyspace = if ENV["KEYSPACE"]
         Virsandra::Keyspace.new(ENV["KEYSPACE"], config_options)
       end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 module IntegrationTestHelper
   def create_keyspace
     Virsandra.keyspace = 'system'
+    Virsandra.username = TEST_USERNAME
+    Virsandra.password = TEST_PASSWORD
     Virsandra.execute("CREATE KEYSPACE #{TEST_KEYSPACE} WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}")
     Virsandra.reset!
   end

--- a/spec/lib/virsandra/configuration_spec.rb
+++ b/spec/lib/virsandra/configuration_spec.rb
@@ -38,11 +38,14 @@ describe Virsandra::Configuration do
   end
 
   describe "to_hash" do
+    let(:given_options){ { credentials: {username: '', password: ''} } }
+
     it "returns all options as a hash" do
       config.to_hash.should eq({
         consistency: :quorum,
         keyspace: nil,
-        servers: "127.0.0.1"
+        servers: "127.0.0.1",
+        credentials: {username: '', password: ''}
       })
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ require 'virsandra'
 
 VIRSANDRA_TEST_ROOT = File.expand_path('..', __FILE__)
 TEST_KEYSPACE = "virtest"
+TEST_USERNAME = ''
+TEST_PASSWORD = ''
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true


### PR DESCRIPTION
Added username and password methods to Virsandra module that update the new configuration credentials hash.
Connection now also passes the credentials hash to the Cql:Client.
