### PR TITLE
Update build matrix to use Rubinius v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 1.9.3
   - 1.9.2
   - jruby-19mode
-  - rbx-19mode
+  - rbx-2
 
 services:
   - cassandra


### PR DESCRIPTION
:information_desk_person: [Travis CI has deprecated `rbx-19mode`](http://docs.travis-ci.com/user/languages/ruby/#Rubinius). This change will fix the build.
