### PR TITLE
Bump Virtus dependency to 1.0

### DIFF
--- a/lib/virsandra/model.rb
+++ b/lib/virsandra/model.rb
@@ -1,7 +1,7 @@
 module Virsandra
   module Model
 
-    include Virtus
+    include Virtus.module
 
     def self.included(base)
       super

--- a/virsandra.gemspec
+++ b/virsandra.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   ]
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "virtus", "~> 0.5.5"
+  gem.add_dependency "virtus", "~> 1.0"
   gem.add_dependency "cql-rb", "~> 1.1.0.pre7"
 
   gem.add_development_dependency "rake", "~>10.0.4"


### PR DESCRIPTION
:information_desk_person: Virtus 1.0 was released in October 2013. This change updates the version used in this gem to use it.

NB, the test build is dependant on #23.
