### PR TITLE
Set required Ruby version to 1.9.3 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 rvm:
   - 2.0.0
   - 1.9.3
-  - 1.9.2
   - jruby-19mode
   - rbx-2
 

--- a/virsandra.gemspec
+++ b/virsandra.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Easily store models defined with Virtus in Cassandra using CQL3}
   gem.homepage      = "https://github.com/ottbot/virsandra"
 
+  gem.required_ruby_version = '>= 1.9.3'
+
   gem.licenses      = ["MIT"]
   gem.files         =  Dir["{lib,vendor}/**/*"] + ["Rakefile", "README.md"]
   gem.test_files    = Dir["{spec}/**/*"]


### PR DESCRIPTION
:information_desk_person: Virtus v1.0 requires Ruby >= 1.9.3. These changes match this requirement.
