### PR TITLE
Allow Cql port configuration

### DIFF
--- a/lib/virsandra.rb
+++ b/lib/virsandra.rb
@@ -61,6 +61,10 @@ module Virsandra
       configuration.keyspace
     end
 
+    def port
+      configuration.port
+    end
+
     def servers
       configuration.servers
     end
@@ -71,6 +75,10 @@ module Virsandra
 
     def keyspace=(value)
       configuration.keyspace = value
+    end
+
+    def port=(value)
+      configuration.port = value
     end
 
     def servers=(value)

--- a/lib/virsandra/configuration.rb
+++ b/lib/virsandra/configuration.rb
@@ -5,6 +5,7 @@ module Virsandra
       :keyspace,
       :servers,
       :credentials,
+      :port,
     ].freeze
 
     DEFAULT_OPTION_VALUES = {

--- a/lib/virsandra/connection.rb
+++ b/lib/virsandra/connection.rb
@@ -17,6 +17,9 @@ module Virsandra
       if @config.credentials.any?
         params.merge!( credentials: @config.credentials )
       end
+      if !@config.port.nil?
+        params.merge!( port: @config.port )
+      end
       @handle = Cql::Client.connect( params )
       @handle.use(@config.keyspace)
       @handle

--- a/spec/lib/virsandra/configuration_spec.rb
+++ b/spec/lib/virsandra/configuration_spec.rb
@@ -38,14 +38,15 @@ describe Virsandra::Configuration do
   end
 
   describe "to_hash" do
-    let(:given_options){ { credentials: {username: '', password: ''} } }
+    let(:given_options){ { credentials: {username: '', password: ''}, port: 1234 } }
 
     it "returns all options as a hash" do
       config.to_hash.should eq({
         consistency: :quorum,
         keyspace: nil,
         servers: "127.0.0.1",
-        credentials: {username: '', password: ''}
+        credentials: {username: '', password: ''},
+        port: 1234
       })
     end
   end

--- a/spec/lib/virsandra/connection_spec.rb
+++ b/spec/lib/virsandra/connection_spec.rb
@@ -37,6 +37,25 @@ describe Virsandra::Connection do
     connection.disconnect!
   end
 
+  describe "connect!" do
+    let(:config_options) { {keyspace: :my_keyspace} }
+    let(:config) { Virsandra::Configuration.new(config_options) }
+
+    it 'uses the default config' do
+      Cql::Client.should_receive(:connect).with(hash_excluding(:port))
+      subject.connect!
+    end
+
+    context "with config port" do
+      let(:config_options) { {keyspace: :my_keyspace, port: 1234 } }
+
+      it 'passes the the port' do
+        Cql::Client.should_receive(:connect).with(hash_including(:port))
+        subject.connect!
+      end
+    end
+  end
+
   describe "#execute" do
     it "should use configuration consistency when none is given" do
       config.consistency = :one

--- a/spec/lib/virsandra_spec.rb
+++ b/spec/lib/virsandra_spec.rb
@@ -77,14 +77,14 @@ describe Virsandra do
   end
 
   describe "delegation to configuration" do
-    [:keyspace, :servers, :consistency, :reset!].each do |method_name|
+    [:keyspace, :servers, :consistency, :reset!, :port].each do |method_name|
       it "should deletege #{method_name} to configuration" do
         config.should_receive(method_name).any_number_of_times.and_return("value")
         described_class.send(method_name).should eq("value")
       end
     end
 
-    [:keyspace=, :servers=, :consistency=].each do |method_name|
+    [:keyspace=, :servers=, :consistency=, :port=].each do |method_name|
       it "should deletege #{method_name} to configuration" do
         config.should_receive(method_name).with("value").any_number_of_times
         described_class.send(method_name, "value")


### PR DESCRIPTION
This is useful when trying to connect to cassandra on a non standard port such as an instance running inside a docker container.
